### PR TITLE
Add apiError logger

### DIFF
--- a/buddi_chat/src/utils/logger.js
+++ b/buddi_chat/src/utils/logger.js
@@ -15,6 +15,7 @@ const logger = {
   info: (...args) => log(logLevels.INFO, 'INFO', ...args),
   warn: (...args) => log(logLevels.WARN, 'WARN', ...args),
   error: (...args) => log(logLevels.ERROR, 'ERROR', ...args),
+  apiError: (...args) => log(logLevels.ERROR, 'API_ERROR', ...args),
 };
 
 function log(level, prefix, ...args) {


### PR DESCRIPTION
## Summary
- extend logger with an `apiError` method to handle API errors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68591fb3735883238efa4c526e880ed0