### PR TITLE
Update imports for auth and services

### DIFF
--- a/buddi_chat/src/App.jsx
+++ b/buddi_chat/src/App.jsx
@@ -1,8 +1,9 @@
-import { Suspense, lazy } from 'react';
+import { Suspense, lazy, useContext } from 'react';
 import { BrowserRouter as Router, Routes, Route, useLocation, Navigate } from 'react-router-dom';
 import ThemeContext from './context/ThemeContext';
 import useAuth from './hooks/useAuth';
 import useOnlineStatus from './hooks/useOnlineStatus';
+import useIdleTimer from './hooks/useIdleTimer';
 import RouteErrorBoundary from './components/RouteErrorBoundary';
 import PrivateRoute from './components/PrivateRoute';
 import Loader from './components/Loader';

--- a/buddi_chat/src/hooks/useAuth.js
+++ b/buddi_chat/src/hooks/useAuth.js
@@ -1,5 +1,5 @@
 import { useEffect, useReducer } from 'react';
-import fetchLoggedInUser from '../services/apiService';
+import { fetchLoggedInUser } from '../services/apiService';
 import logger from '../utils/logger';
 import {webSocketService} from '../services/webSocketService';
 

--- a/buddi_chat/src/services/apiService.js
+++ b/buddi_chat/src/services/apiService.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import crypto from 'crypto';
 
 // Configuration
 const baseURL = import.meta.env.VITE_API_URL || 'http://localhost:5001/api';

--- a/buddi_chat/src/services/webSocketService.js
+++ b/buddi_chat/src/services/webSocketService.js
@@ -1,5 +1,6 @@
 import logger from '../utils/logger';
-import fetchLoggedInUser from './apiService';
+import { fetchLoggedInUser } from './apiService';
+import crypto from 'crypto';
 
 const WS_CONFIG = {
   RECONNECT_BASE_DELAY: 1000,


### PR DESCRIPTION
## Summary
- switch to named import for `fetchLoggedInUser`
- add `crypto` imports in service modules
- import `useContext` and `useIdleTimer` in `App.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68591fb17a0c8323a0eca33203a94785